### PR TITLE
Feed: update: Added a summary at the end

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -3391,8 +3391,13 @@ class Feed
     public function updateFeedsHash($feedsHash, $force, $format = '')
     {
         $i = 0;
+        $errorCount = 0;
+        $noUpdateCount = 0;
+        $successCount = 0;
+        $nbItemsAdded = 0;
 
         $feedsHash = $this->orderFeedsForUpdate($feedsHash);
+        $nbFeeds = count($feedsHash);
 
         ob_end_flush();
         if (ob_get_level() == 0) ob_start();
@@ -3411,10 +3416,11 @@ class Feed
               <tbody>';
         }
         $start = microtime(true);
+        $lastTime = $start;
         foreach ($feedsHash as $feedHash) {
             $i++;
             $feed = $this->getFeed($feedHash);
-            $strBegin = "\n".'<tr><td>'.str_pad($i.'/'.count($feedsHash), 7, ' ', STR_PAD_LEFT).'</td><td> <a href="?currentHash='.$feedHash.'">'.substr(str_pad($feed['title'], 50), 0, 50).'</a> </td><td>';
+            $strBegin = "\n".'<tr><td>'.str_pad($i.'/'.$nbFeeds, 7, ' ', STR_PAD_LEFT).'</td><td> <a href="?currentHash='.$feedHash.'">'.substr(str_pad($feed['title'], 50), 0, 50).'</a> </td><td>';
             if ($format === 'html') {
                 echo str_pad($strBegin, 4096);
                 ob_flush();
@@ -3422,16 +3428,23 @@ class Feed
             }
 
             $strEnd = '';
+            $time = microtime(true) - $lastTime;
+            $lastTime += $time;
             if ($force or $this->needUpdate($feed)) {
                 $info = $this->updateChannel($feedHash, $force);
-                $strEnd .= '<span class="text-success">'.str_pad(count($info['newItems']), 3, ' ', STR_PAD_LEFT).'</span> </td><td>'.str_pad(number_format(microtime(true)-$start, 1), 6, ' ', STR_PAD_LEFT).'s </td><td>';
+                $countItems = count($info['newItems']);
+                $strEnd .= '<span class="text-success">'.str_pad($countItems, 3, ' ', STR_PAD_LEFT).'</span> </td><td>'.str_pad(number_format($time, 1), 6, ' ', STR_PAD_LEFT).'s </td><td>';
                 if (empty($info['error'])) {
                     $strEnd .= Intl::msg('Successfully updated').'</td></tr>';
+                    $successCount++;
+                    $nbItemsAdded += $countItems;
                 } else {
                     $strEnd .= '<span class="text-error">'.$info['error'].'</span></td></tr>';
+                    $errorCount++;
                 }
             } else {
-                $strEnd .= str_pad('0', 3, ' ', STR_PAD_LEFT).' </td><td>'.str_pad(number_format(microtime(true)-$start, 1), 6, ' ', STR_PAD_LEFT).'s </td><td><span class="text-warning">'.Intl::msg('Already up-to-date').'</span></td></tr>';
+                $strEnd .= str_pad('0', 3, ' ', STR_PAD_LEFT).' </td><td>'.str_pad(number_format($time, 1), 6, ' ', STR_PAD_LEFT).'s </td><td><span class="text-warning">'.Intl::msg('Already up-to-date').'</span></td></tr>';
+                $noUpdateCount++;
             }
             if ($format==='html') {
                 echo str_pad($strEnd,4096);
@@ -3441,6 +3454,27 @@ class Feed
                 echo strip_tags($strBegin.$strEnd);
             }
         }
+
+        // summary
+        $strBegin = "\n".'<tr><td></td><td> '.Intl::msg('Total:').' '.$nbFeeds.' '.Intl::msg('items').'</td><td>';
+        if ($format === 'html') {
+            echo str_pad($strBegin, 4096);
+            ob_flush();
+            flush();
+        }
+
+        $strEnd = str_pad($nbItemsAdded, 3, ' ', STR_PAD_LEFT).' </td><td>'.str_pad(number_format(microtime(true) - $start, 1), 6, ' ', STR_PAD_LEFT).'s </td><td>'
+            .'<span class="text-success">'.$successCount.' '.($successCount > 1 ? Intl::msg('Successes') : Intl::msg('Success')).'</span><br />'
+            .'<span class="text-warning">'.$noUpdateCount.' '.Intl::msg('Up-to-date').'</span><br />'
+            .'<span class="text-error">'.$errorCount.' '.($errorCount > 1 ? Intl::msg('Errors') : Intl::msg('Error')).'</span></td></tr>';
+        if ($format === 'html') {
+            echo str_pad($strEnd, 4096);
+            ob_flush();
+            flush();
+        } else {
+            echo strip_tags($strBegin.$strEnd);
+        }
+
         if ($format === 'html') {
             echo '</tbody></table>';
         }

--- a/src/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/src/locale/fr_FR/LC_MESSAGES/messages.po
@@ -171,6 +171,34 @@ msgstr "Mise à jour réussie"
 msgid "Already up-to-date"
 msgstr "Déjà à jour"
 
+#: class/Feed.php:1315
+msgid "Total:"
+msgstr "Total :"
+
+#: class/Feed.php:1315
+msgid "items"
+msgstr "éléments"
+
+#: class/Feed.php:1323
+msgid "Successes"
+msgstr "Succès"
+
+#: class/Feed.php:1323
+msgid "Success"
+msgstr "Succès"
+
+#: class/Feed.php:1324
+msgid "Up-to-date"
+msgstr "À jour"
+
+#: class/Feed.php:1325
+msgid "Errors"
+msgstr "Erreurs"
+
+#: class/Feed.php:1325
+msgid "Error"
+msgstr "Erreur"
+
 #: class/MyTool.php:140
 msgid "Http code not valid"
 msgstr "Code http non valide"

--- a/src/locale/messages.pot
+++ b/src/locale/messages.pot
@@ -112,28 +112,56 @@ msgstr ""
 msgid "Items may have been missed since last update"
 msgstr ""
 
-#: class/Feed.php:1261
+#: class/Feed.php:1266
 msgid "Feed"
 msgstr ""
 
-#: class/Feed.php:1262
+#: class/Feed.php:1267
 msgid "New items"
 msgstr ""
 
-#: class/Feed.php:1263
+#: class/Feed.php:1268
 msgid "Time"
 msgstr ""
 
-#: class/Feed.php:1264
+#: class/Feed.php:1269
 msgid "Status"
 msgstr ""
 
-#: class/Feed.php:1285
+#: class/Feed.php:1294
 msgid "Successfully updated"
 msgstr ""
 
-#: class/Feed.php:1290
+#: class/Feed.php:1302
 msgid "Already up-to-date"
+msgstr ""
+
+#: class/Feed.php:1315
+msgid "Total:"
+msgstr ""
+
+#: class/Feed.php:1315
+msgid "items"
+msgstr ""
+
+#: class/Feed.php:1323
+msgid "Successes"
+msgstr ""
+
+#: class/Feed.php:1323
+msgid "Success"
+msgstr ""
+
+#: class/Feed.php:1324
+msgid "Up-to-date"
+msgstr ""
+
+#: class/Feed.php:1325
+msgid "Errors"
+msgstr ""
+
+#: class/Feed.php:1325
+msgid "Error"
 msgstr ""
 
 #: class/MyTool.php:140


### PR DESCRIPTION
Hello tontof!

Here is a very small change just to add a summary at the end of the update:

> A new row has been added to show the number of items, the number of errors/succeses/up-to-date and the total elapsed time.
> Note: the time column now displays the elapsed time to update each corresponding item and not the elapsed time since the first action.

I don't know if you want it but I wanted to have this summary and this is why I added it

Note that I'm not so familiar with PHP and I hope that I've respected your conventions :-)
Feel free to modify the code or to reject the pull request if you don't like it ;-)

Also, I didn't installed php5 just to update the locale files, this is why `$messages['fr_FR']` variable has not been updated in 'index.php' file (I just updated `locale/fr_FR/LC_MESSAGES/messages.po` by hand) :-)
