### PR TITLE
Cookie through SSL

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -4870,7 +4870,13 @@ class Session
         if(dirname($_SERVER['SCRIPT_NAME'])!='/') {
             $cookiedir = dirname($_SERVER["SCRIPT_NAME"]).'/';
         }
-        session_set_cookie_params($cookie['lifetime'], $cookiedir);
+        $ssl = false;
+
+        if(isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
+            $ssl = true;
+        }
+                
+        session_set_cookie_params($cookie['lifetime'], $cookiedir, $cookie['domain'], $ssl);
         // Use cookies to store session.
         ini_set('session.use_cookies', 1);
         // Force cookies for session  (phpsessionID forbidden in URL)


### PR DESCRIPTION
J'ai des soucis avec le login de KrISS sur mon serveur. Je suis en SSL, et je me retrouve tout le temps déconnecté (avec un alert javascript "vous avez été déconnecté"). 

Cette modification fait que le cookie sera transmis uniquement par SSL, et est activé quand la page est en SSL, donc cela n'a pas d'incidence sur les hébergements non-ssl. Par contre, ça a résolu mon problème

Je n'exclu pas que l'origine du serveur soit ma configuration de php, mais je n'ai pas ce genre de problème sur les "gros" script type WordPress
