### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -3284,7 +3284,7 @@ class Feed
                 }
                 $newItemsHash = array_keys($newItems);
                 $this->_data['feeds'][$feedHash]['items']
-                    = $newItems+$oldItems;
+                    = (is_array($newItems) ? $newItems : Array()) + (is_array($oldItems) ? $oldItems : Array());
 
                 // Check if items may have been missed
                 if (count($oldItems) !== 0 and count($rssItemsHash) === count($newItemsHash)) {


### PR DESCRIPTION
Parfois, à la mise à jour des flux par cron, le message d'erreur PHP "Fatal error: Unsupported operand types in index.php on line 3288". Il s'avère que c'est parce qu'une des deux variables $newItems ou $oldItems n'est pas un tableau, et donc la concaténation des deux variables ne peut aboutir.