### PR TITLE
Add meta tag to block sending the referrer

### DIFF
--- a/src/class/tpl/includes.html
+++ b/src/class/tpl/includes.html
@@ -1,6 +1,7 @@
     <base href="{$base;}">
     <title>{$pagetitle}</title>
     <meta charset="utf-8">
+    <meta name="referrer" content="no-referrer">
 {if="is_file('inc/favicon.ico')"}
     <link href="inc/favicon.ico" rel="icon" type="image/x-icon">
 {else}


### PR DESCRIPTION
Add a meta tag that tells the browser not to send the referrer header.