### PR TITLE
use HTTP_HOST instead of SERVER_NAME

### DIFF
--- a/src/class/MyTool.php
+++ b/src/class/MyTool.php
@@ -339,12 +339,12 @@ class MyTool
 
         $scriptname = str_replace('/index.php', '/', $_SERVER["SCRIPT_NAME"]);
 
-        if (!isset($_SERVER["SERVER_NAME"])) {
+        if (!isset($_SERVER["HTTP_HOST"])) {
             return $scriptname;
         }
 
         return 'http' . ($https ? 's' : '') . '://'
-            . $_SERVER["SERVER_NAME"] . $serverport . $scriptname;
+            . $_SERVER["HTTP_HOST"] . $serverport . $scriptname;
     }
 
     /**


### PR DESCRIPTION
Enchanté!

could you please consider changing SERVER_NAME to HTTP_HOST?
SERVER_NAME usually contains internally used name (single-element hostname, or other address see https://tools.ietf.org/html/rfc3875#section-4.1.14), but here we need the user-facing hostname which is in her URL bar in the browser. IMO it's HTTP_HOST which is the most appropriative variable for this.

Merci.