### PR TITLE
Remove warning when using PHP 7.3

### DIFF
--- a/src/class/Intl.php
+++ b/src/class/Intl.php
@@ -207,7 +207,7 @@ class Intl
                 default:        break;
                 }
                                                         
-                continue;
+                continue 2;
                 break;
 
             case 'msgctxt' :

--- a/src/class/MyTool.php
+++ b/src/class/MyTool.php
@@ -392,14 +392,15 @@ class MyTool
     {
         $val  = trim($val);
         $last = strtolower($val[strlen($val)-1]);
+        $value = intval($val);
         switch($last)
         {
-        case 'g': $val *= 1024;
-        case 'm': $val *= 1024;
-        case 'k': $val *= 1024;
+        case 'g': $value *= 1024;
+        case 'm': $value *= 1024;
+        case 'k': $value *= 1024;
         }
 
-        return $val;
+        return $value;
     }
 
     /**


### PR DESCRIPTION
* Fix issue related to numeric values (direct cast from string is raising a warning)
* Fix issue during installation linked to `continue` during switch (needed `continue 2`)

First warning is also causing an issue during usage of make.php as the warning is included inside the script.